### PR TITLE
Use cname for depot.galaxyproject.org in rsync

### DIFF
--- a/get_container_list.py
+++ b/get_container_list.py
@@ -88,6 +88,6 @@ with open('build.sh', 'w') as f:
     c_no = 1
     #for container in sorted(lst, reverse=True):
     for container in sorted(lst):
-        f.write("sudo singularity build {0} docker://quay.io/biocontainers/{0} > /dev/null 2>&1 && rsync -azqe ssh ./{0} singularity@orval.galaxyproject.org:/srv/nginx/depot.galaxyproject.org/root/singularity/ && rm {0} && echo 'Container {1} ({0}) of {2} built.'\n".format(container, c_no, len(lst)))
+        f.write("sudo singularity build {0} docker://quay.io/biocontainers/{0} > /dev/null 2>&1 && rsync -azqe ssh ./{0} singularity@depot.galaxyproject.org:/srv/nginx/depot.galaxyproject.org/root/singularity/ && rm {0} && echo 'Container {1} ({0}) of {2} built.'\n".format(container, c_no, len(lst)))
         c_no += 1
 print('{} containers found. Building...'.format(len(lst)))


### PR DESCRIPTION
We are migrating depot to a new system, the underlying hostname will change from orval but the depot cname will update to point at the new system.